### PR TITLE
changed dataout timing type & switched to UNIX line endings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 See [README.md](https://github.com/The-OpenROAD-Project/asap7)
+
+**2024/09/18**
+- Updated Liberty files to use rising_edge timing_type on dataout timing paths. Otherwise, the macro timing paths aren't properly in ORFS
+- Switched from DOS line endings to Unix line endings
+  

--- a/generated/LIB/srambank_128x4x16_6t122.lib
+++ b/generated/LIB/srambank_128x4x16_6t122.lib
@@ -1038,7 +1038,7 @@ library (srambank_128x4x16_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_128x4x18_6t122.lib
+++ b/generated/LIB/srambank_128x4x18_6t122.lib
@@ -1066,7 +1066,7 @@ library (srambank_128x4x18_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_128x4x20_6t122.lib
+++ b/generated/LIB/srambank_128x4x20_6t122.lib
@@ -1094,7 +1094,7 @@ library (srambank_128x4x20_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_128x4x32_6t122.lib
+++ b/generated/LIB/srambank_128x4x32_6t122.lib
@@ -1262,7 +1262,7 @@ library (srambank_128x4x32_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_128x4x34_6t122.lib
+++ b/generated/LIB/srambank_128x4x34_6t122.lib
@@ -1290,7 +1290,7 @@ library (srambank_128x4x34_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_128x4x36_6t122.lib
+++ b/generated/LIB/srambank_128x4x36_6t122.lib
@@ -1318,7 +1318,7 @@ library (srambank_128x4x36_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_128x4x40_6t122.lib
+++ b/generated/LIB/srambank_128x4x40_6t122.lib
@@ -1374,7 +1374,7 @@ library (srambank_128x4x40_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_128x4x48_6t122.lib
+++ b/generated/LIB/srambank_128x4x48_6t122.lib
@@ -1486,7 +1486,7 @@ library (srambank_128x4x48_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_128x4x64_6t122.lib
+++ b/generated/LIB/srambank_128x4x64_6t122.lib
@@ -1710,7 +1710,7 @@ library (srambank_128x4x64_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_128x4x72_6t122.lib
+++ b/generated/LIB/srambank_128x4x72_6t122.lib
@@ -1822,7 +1822,7 @@ library (srambank_128x4x72_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_128x4x74_6t122.lib
+++ b/generated/LIB/srambank_128x4x74_6t122.lib
@@ -1850,7 +1850,7 @@ library (srambank_128x4x74_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_128x4x80_6t122.lib
+++ b/generated/LIB/srambank_128x4x80_6t122.lib
@@ -1934,7 +1934,7 @@ library (srambank_128x4x80_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_256x4x16_6t122.lib
+++ b/generated/LIB/srambank_256x4x16_6t122.lib
@@ -1048,7 +1048,7 @@ library (srambank_256x4x16_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_256x4x18_6t122.lib
+++ b/generated/LIB/srambank_256x4x18_6t122.lib
@@ -1076,7 +1076,7 @@ library (srambank_256x4x18_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_256x4x20_6t122.lib
+++ b/generated/LIB/srambank_256x4x20_6t122.lib
@@ -1104,7 +1104,7 @@ library (srambank_256x4x20_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_256x4x32_6t122.lib
+++ b/generated/LIB/srambank_256x4x32_6t122.lib
@@ -1272,7 +1272,7 @@ library (srambank_256x4x32_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_256x4x34_6t122.lib
+++ b/generated/LIB/srambank_256x4x34_6t122.lib
@@ -1300,7 +1300,7 @@ library (srambank_256x4x34_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_256x4x36_6t122.lib
+++ b/generated/LIB/srambank_256x4x36_6t122.lib
@@ -1328,7 +1328,7 @@ library (srambank_256x4x36_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_256x4x40_6t122.lib
+++ b/generated/LIB/srambank_256x4x40_6t122.lib
@@ -1384,7 +1384,7 @@ library (srambank_256x4x40_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_256x4x48_6t122.lib
+++ b/generated/LIB/srambank_256x4x48_6t122.lib
@@ -1496,7 +1496,7 @@ library (srambank_256x4x48_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_256x4x64_6t122.lib
+++ b/generated/LIB/srambank_256x4x64_6t122.lib
@@ -1720,7 +1720,7 @@ library (srambank_256x4x64_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_256x4x72_6t122.lib
+++ b/generated/LIB/srambank_256x4x72_6t122.lib
@@ -1832,7 +1832,7 @@ library (srambank_256x4x72_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_256x4x74_6t122.lib
+++ b/generated/LIB/srambank_256x4x74_6t122.lib
@@ -1860,7 +1860,7 @@ library (srambank_256x4x74_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_256x4x80_6t122.lib
+++ b/generated/LIB/srambank_256x4x80_6t122.lib
@@ -1944,7 +1944,7 @@ library (srambank_256x4x80_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_64x4x16_6t122.lib
+++ b/generated/LIB/srambank_64x4x16_6t122.lib
@@ -1028,7 +1028,7 @@ library (srambank_64x4x16_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_64x4x18_6t122.lib
+++ b/generated/LIB/srambank_64x4x18_6t122.lib
@@ -1056,7 +1056,7 @@ library (srambank_64x4x18_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_64x4x20_6t122.lib
+++ b/generated/LIB/srambank_64x4x20_6t122.lib
@@ -1084,7 +1084,7 @@ library (srambank_64x4x20_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_64x4x32_6t122.lib
+++ b/generated/LIB/srambank_64x4x32_6t122.lib
@@ -1252,7 +1252,7 @@ library (srambank_64x4x32_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_64x4x34_6t122.lib
+++ b/generated/LIB/srambank_64x4x34_6t122.lib
@@ -1280,7 +1280,7 @@ library (srambank_64x4x34_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_64x4x36_6t122.lib
+++ b/generated/LIB/srambank_64x4x36_6t122.lib
@@ -1308,7 +1308,7 @@ library (srambank_64x4x36_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_64x4x40_6t122.lib
+++ b/generated/LIB/srambank_64x4x40_6t122.lib
@@ -1364,7 +1364,7 @@ library (srambank_64x4x40_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_64x4x48_6t122.lib
+++ b/generated/LIB/srambank_64x4x48_6t122.lib
@@ -1476,7 +1476,7 @@ library (srambank_64x4x48_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_64x4x64_6t122.lib
+++ b/generated/LIB/srambank_64x4x64_6t122.lib
@@ -1700,7 +1700,7 @@ library (srambank_64x4x64_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_64x4x72_6t122.lib
+++ b/generated/LIB/srambank_64x4x72_6t122.lib
@@ -1812,7 +1812,7 @@ library (srambank_64x4x72_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_64x4x74_6t122.lib
+++ b/generated/LIB/srambank_64x4x74_6t122.lib
@@ -1840,7 +1840,7 @@ library (srambank_64x4x74_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");

--- a/generated/LIB/srambank_64x4x80_6t122.lib
+++ b/generated/LIB/srambank_64x4x80_6t122.lib
@@ -1924,7 +1924,7 @@ library (srambank_64x4x80_6t122) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");


### PR DESCRIPTION
Switched timing_type for dataout-related paths from combinational to rising_edge.

Updated to use UNIX line endings