### PR TITLE
Add area to `.lib` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 See [README.md](https://github.com/The-OpenROAD-Project/asap7)
 
+**2025/10/20**
+- Add the macro area computed from the LEF file to the LIB file
+
 **2024/09/18**
 - Updated Liberty files to use rising_edge timing_type on dataout timing paths. Otherwise, the macro timing paths aren't properly in ORFS
 - Switched from DOS line endings to Unix line endings

--- a/generated/LIB/srambank_128x4x16_6t122.lib
+++ b/generated/LIB/srambank_128x4x16_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_128x4x16_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_128x4x16_6t122) {
-    area : 0;
+    area : 414.72;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_128x4x18_6t122.lib
+++ b/generated/LIB/srambank_128x4x18_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_128x4x18_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_128x4x18_6t122) {
-    area : 0;
+    area : 449.28;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_128x4x20_6t122.lib
+++ b/generated/LIB/srambank_128x4x20_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_128x4x20_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_128x4x20_6t122) {
-    area : 0;
+    area : 483.84;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_128x4x32_6t122.lib
+++ b/generated/LIB/srambank_128x4x32_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_128x4x32_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_128x4x32_6t122) {
-    area : 0;
+    area : 691.2;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_128x4x34_6t122.lib
+++ b/generated/LIB/srambank_128x4x34_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_128x4x34_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_128x4x34_6t122) {
-    area : 0;
+    area : 725.76;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_128x4x36_6t122.lib
+++ b/generated/LIB/srambank_128x4x36_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_128x4x36_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_128x4x36_6t122) {
-    area : 0;
+    area : 760.32;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_128x4x40_6t122.lib
+++ b/generated/LIB/srambank_128x4x40_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_128x4x40_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_128x4x40_6t122) {
-    area : 0;
+    area : 829.44;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_128x4x48_6t122.lib
+++ b/generated/LIB/srambank_128x4x48_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_128x4x48_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_128x4x48_6t122) {
-    area : 0;
+    area : 967.68;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_128x4x64_6t122.lib
+++ b/generated/LIB/srambank_128x4x64_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_128x4x64_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_128x4x64_6t122) {
-    area : 0;
+    area : 1244.16;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_128x4x72_6t122.lib
+++ b/generated/LIB/srambank_128x4x72_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_128x4x72_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_128x4x72_6t122) {
-    area : 0;
+    area : 1382.4;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_128x4x74_6t122.lib
+++ b/generated/LIB/srambank_128x4x74_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_128x4x74_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_128x4x74_6t122) {
-    area : 0;
+    area : 1416.96;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_128x4x80_6t122.lib
+++ b/generated/LIB/srambank_128x4x80_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_128x4x80_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_128x4x80_6t122) {
-    area : 0;
+    area : 1520.64;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_256x4x16_6t122.lib
+++ b/generated/LIB/srambank_256x4x16_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_256x4x16_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_256x4x16_6t122) {
-    area : 0;
+    area : 786.62016;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_256x4x18_6t122.lib
+++ b/generated/LIB/srambank_256x4x18_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_256x4x18_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_256x4x18_6t122) {
-    area : 0;
+    area : 852.17184;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_256x4x20_6t122.lib
+++ b/generated/LIB/srambank_256x4x20_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_256x4x20_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_256x4x20_6t122) {
-    area : 0;
+    area : 917.72352;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_256x4x32_6t122.lib
+++ b/generated/LIB/srambank_256x4x32_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_256x4x32_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_256x4x32_6t122) {
-    area : 0;
+    area : 1311.0336;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_256x4x34_6t122.lib
+++ b/generated/LIB/srambank_256x4x34_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_256x4x34_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_256x4x34_6t122) {
-    area : 0;
+    area : 1376.58528;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_256x4x36_6t122.lib
+++ b/generated/LIB/srambank_256x4x36_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_256x4x36_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_256x4x36_6t122) {
-    area : 0;
+    area : 1442.13696;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_256x4x40_6t122.lib
+++ b/generated/LIB/srambank_256x4x40_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_256x4x40_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_256x4x40_6t122) {
-    area : 0;
+    area : 1573.24032;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_256x4x48_6t122.lib
+++ b/generated/LIB/srambank_256x4x48_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_256x4x48_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_256x4x48_6t122) {
-    area : 0;
+    area : 1835.44704;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_256x4x64_6t122.lib
+++ b/generated/LIB/srambank_256x4x64_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_256x4x64_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_256x4x64_6t122) {
-    area : 0;
+    area : 2359.86048;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_256x4x72_6t122.lib
+++ b/generated/LIB/srambank_256x4x72_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_256x4x72_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_256x4x72_6t122) {
-    area : 0;
+    area : 2622.0672;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_256x4x74_6t122.lib
+++ b/generated/LIB/srambank_256x4x74_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_256x4x74_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_256x4x74_6t122) {
-    area : 0;
+    area : 2687.61888;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_256x4x80_6t122.lib
+++ b/generated/LIB/srambank_256x4x80_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_256x4x80_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_256x4x80_6t122) {
-    area : 0;
+    area : 2884.27392;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_64x4x16_6t122.lib
+++ b/generated/LIB/srambank_64x4x16_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_64x4x16_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_64x4x16_6t122) {
-    area : 0;
+    area : 249.14304;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_64x4x18_6t122.lib
+++ b/generated/LIB/srambank_64x4x18_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_64x4x18_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_64x4x18_6t122) {
-    area : 0;
+    area : 269.90496;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_64x4x20_6t122.lib
+++ b/generated/LIB/srambank_64x4x20_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_64x4x20_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_64x4x20_6t122) {
-    area : 0;
+    area : 290.66688;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_64x4x32_6t122.lib
+++ b/generated/LIB/srambank_64x4x32_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_64x4x32_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_64x4x32_6t122) {
-    area : 0;
+    area : 415.2384;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_64x4x34_6t122.lib
+++ b/generated/LIB/srambank_64x4x34_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_64x4x34_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_64x4x34_6t122) {
-    area : 0;
+    area : 436.00032;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_64x4x36_6t122.lib
+++ b/generated/LIB/srambank_64x4x36_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_64x4x36_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_64x4x36_6t122) {
-    area : 0;
+    area : 456.76224;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_64x4x40_6t122.lib
+++ b/generated/LIB/srambank_64x4x40_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_64x4x40_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_64x4x40_6t122) {
-    area : 0;
+    area : 498.28608;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_64x4x48_6t122.lib
+++ b/generated/LIB/srambank_64x4x48_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_64x4x48_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_64x4x48_6t122) {
-    area : 0;
+    area : 581.33376;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_64x4x64_6t122.lib
+++ b/generated/LIB/srambank_64x4x64_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_64x4x64_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_64x4x64_6t122) {
-    area : 0;
+    area : 747.42912;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_64x4x72_6t122.lib
+++ b/generated/LIB/srambank_64x4x72_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_64x4x72_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_64x4x72_6t122) {
-    area : 0;
+    area : 830.4768;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_64x4x74_6t122.lib
+++ b/generated/LIB/srambank_64x4x74_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_64x4x74_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_64x4x74_6t122) {
-    area : 0;
+    area : 851.23872;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;

--- a/generated/LIB/srambank_64x4x80_6t122.lib
+++ b/generated/LIB/srambank_64x4x80_6t122.lib
@@ -99,7 +99,7 @@ library (srambank_64x4x80_6t122) {
     index_2 ("0.00072, 0.00144, 0.00288, 0.00576, 0.01152, 0.02304, 0.04608");
   }
   cell (srambank_64x4x80_6t122) {
-    area : 0;
+    area : 913.52448;
     cell_leakage_power : 0;
     dont_use : true;
     interface_timing : true;


### PR DESCRIPTION
This PR updates the `.lib` files to include the correct area for all memory macros, which was taken from the `.lef` files. Previously, the area in the `.lib` files was set to zero.